### PR TITLE
Django LTS 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ python:
     - 3.3
     - 3.4
 env:
-    - DEPENDENCIES='django>=1.2,<1.3'
     - DEPENDENCIES='django>=1.3,<1.4'
     - DEPENDENCIES='django>=1.4,<1.5'
     - DEPENDENCIES='django>=1.5,<1.6'
     - DEPENDENCIES='django>=1.6,<1.7'
     - DEPENDENCIES='django>=1.7,<1.8'
+    - DEPENDENCIES='django>=1.8,<1.9'
     - DEPENDENCIES='django'
 install:
     - pip install $DEPENDENCIES 
@@ -23,13 +23,9 @@ matrix:
     - python: 2.6
       env: DEPENDENCIES='django'
     - python: 3.3
-      env: DEPENDENCIES='django>=1.2,<1.3'
-    - python: 3.3
       env: DEPENDENCIES='django>=1.3,<1.4'
     - python: 3.3
       env: DEPENDENCIES='django>=1.4,<1.5'
-    - python: 3.4
-      env: DEPENDENCIES='django>=1.2,<1.3'
     - python: 3.4
       env: DEPENDENCIES='django>=1.3,<1.4'
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - DEPENDENCIES='django>=1.5,<1.6'
     - DEPENDENCIES='django>=1.6,<1.7'
     - DEPENDENCIES='django>=1.7,<1.8'
-    - DEPENDENCIES='django>=1.8,<1.9'
+    - DEPENDENCIES='https://www.djangoproject.com/download/1.8a1/tarball/'
     - DEPENDENCIES='django'
 install:
     - pip install $DEPENDENCIES 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
     - python: 2.6
       env: DEPENDENCIES='django>=1.7,<1.8'
     - python: 2.6
+      env: DEPENDENCIES='https://www.djangoproject.com/download/1.8a1/tarball/'
+    - python: 2.6
       env: DEPENDENCIES='django'
     - python: 3.3
       env: DEPENDENCIES='django>=1.3,<1.4'

--- a/classytags/test/context_managers.py
+++ b/classytags/test/context_managers.py
@@ -41,8 +41,8 @@ class TemplateTags(object):  # pragma: no cover
             self.lib.tag(tag)
 
     def __enter__(self):
-        self.old = list(template.builtins)
-        template.builtins.insert(0, self.lib)
+        self.old = list(template.base.builtins)
+        template.base.builtins.insert(0, self.lib)
 
     def __exit__(self, type, value, traceback):
-        template.builtins[:] = self.old
+        template.base.builtins[:] = self.old

--- a/classytags/test/project/testrunner.py
+++ b/classytags/test/project/testrunner.py
@@ -1,6 +1,9 @@
 from django.conf import settings  # pragma: no cover
-from django.test.simple import DjangoTestSuiteRunner  # pragma: no cover
-
+try:
+    from django.test.simple import DjangoTestSuiteRunner  # pragma: no cover
+except:
+    from django.test.runner import DiscoverRunner
+    DjangoTestSuiteRunner = DiscoverRunner
 try:  # pragma: no cover
     from xmlrunner import XMLTestRunner as runner
 except:  # pragma: no cover

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,12 @@
 Changelog
 #########
 
+*****
+0.5.3
+*****
+
+* Adopt changes to the Django 1.8 test module. Breaks backward compatibility to Django 1.2 for the tests.
+
 
 *****
 0.5.2

--- a/runtests.py
+++ b/runtests.py
@@ -2,6 +2,7 @@
 import warnings
 import os
 import sys
+from django import VERSION
 
 urlpatterns = []
 
@@ -24,9 +25,12 @@ TEMPLATE_DIRS = [
     os.path.join(os.path.dirname(__file__), 'test_templates'),
 ]
 
+if VERSION >= (1,6):
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+else:
+    TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
 
 ROOT_URLCONF = 'runtests'
-
 
 def main():
     import django
@@ -35,7 +39,7 @@ def main():
         INSTALLED_APPS = INSTALLED_APPS,
         ROOT_URLCONF = ROOT_URLCONF,
         DATABASES = DATABASES,
-        TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner',
+        TEST_RUNNER = TEST_RUNNER,
         TEMPLATE_DIRS = TEMPLATE_DIRS,
         TEMPLATE_DEBUG = TEMPLATE_DEBUG,
         MIDDLEWARE_CLASSES = [],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages = find_packages(),
     zip_safe=False,
     install_requires=[
-        'Django>1.2',
+        'Django>1.3',
     ],
     test_suite='runtests.main',
     classifiers=[


### PR DESCRIPTION
Deprecations in Django 1.8:
* [DjangoTestSuiteRunner](https://docs.djangoproject.com/en/1.8/releases/1.8/#features-removed-in-1-8)
* [undocumented API](https://github.com/django/django/commit/7eefdbf7ab9f5bafe5baae2b877d93efc90e3044#diff-736834a23168836e5e3f0ce577d8488dL76)

Tested in Django 1.4.19 & 1.8a1