### PR TITLE
fixed an issue with recursive inclusion tags on Django 1.8

### DIFF
--- a/classytags/helpers.py
+++ b/classytags/helpers.py
@@ -83,7 +83,7 @@ class InclusionTag(Tag):
             safe_context.update(**data)
             output = render_to_string(template, safe_context)
         else:
-            data = self.get_context(context, **kwargs)
+            data = context.new(self.get_context(context, **kwargs))
             output = render_to_string(template, data)
         return output
 


### PR DESCRIPTION
Hi,
today at the Pycon.it together with @yakky we've found an issue with the `show_menu` template tag of django-cms on Django 1.8. I don't fully understand this patch, to be honest, but it seems to solve the issue.

Tried on Django 1.6, 1.7, 1.8.

/cc @nostalgiaz