### PR TITLE
issue number #28

### DIFF
--- a/classytags/helpers.py
+++ b/classytags/helpers.py
@@ -83,7 +83,7 @@ class InclusionTag(Tag):
             safe_context.update(**data)
             output = render_to_string(template, safe_context)
         else:
-            new_context = context.new(self.get_context(context, **kwargs))
+            new_context = context.new(flatten_context(self.get_context(context, **kwargs)))
             data = flatten_context(new_context)
             output = render_to_string(template, data)
         return output

--- a/classytags/helpers.py
+++ b/classytags/helpers.py
@@ -83,7 +83,8 @@ class InclusionTag(Tag):
             safe_context.update(**data)
             output = render_to_string(template, safe_context)
         else:
-            data = context.new(self.get_context(context, **kwargs))
+            new_context = context.new(self.get_context(context, **kwargs))
+            data = flatten_context(new_context)
             output = render_to_string(template, data)
         return output
 

--- a/classytags/utils.py
+++ b/classytags/utils.py
@@ -83,8 +83,9 @@ def mixin(parent, child, attrs={}):
 def flatten_context(context):
     if callable(getattr(context, 'flatten', None)):
         return context.flatten()
-    else:
+    elif hasattr(context, 'dicts'):
         flat = {}
         for d in context.dicts:
             flat.update(d)
         return flat
+    return context


### PR DESCRIPTION
removes warning below:
```
/usr/local/lib/python3.4/dist-packages/django/template/loader.py:97: RemovedInDjango110Warning: render() must be called with a dict, not a RequestContext.
  return template.render(context, request)
```