### PR TITLE
Fix 500 error when context has RequestContext in its dicts.

### DIFF
--- a/classytags/tests.py
+++ b/classytags/tests.py
@@ -10,6 +10,8 @@ from unittest import TestCase
 import django
 from django import template
 from django.core.exceptions import ImproperlyConfigured
+from django.template import Context, RequestContext
+from django.test import RequestFactory
 
 from classytags import arguments
 from classytags import core
@@ -23,7 +25,6 @@ from classytags.blocks import VariableBlockName
 from classytags.compat import compat_next
 from classytags.test.context_managers import SettingsOverride
 from classytags.test.context_managers import TemplateTags
-from django.template import Context
 
 DJANGO_1_4_OR_HIGHER = (
     LooseVersion(django.get_version()) >= LooseVersion('1.4')
@@ -1381,9 +1382,9 @@ class MultiBreakpointTests(TestCase):
         }
         if DJANGO_1_5_OR_HIGHER:
             expected.update({
-            'None': None,
-            'True': True,
-            'False': False,
+                'None': None,
+                'True': True,
+                'False': False,
             })
         self.assertEqual(flat, expected)
         context.flatten = None
@@ -1391,3 +1392,54 @@ class MultiBreakpointTests(TestCase):
         self.assertEqual(flat, expected)
         flat = utils.flatten_context({'foo': 'test', 'bar': 'baz'})
         self.assertEqual(flat, {'foo': 'test', 'bar': 'baz'})
+
+    def test_flatten_requestcontext(self):
+        factory = RequestFactory()
+        request = factory.get('/')
+        expected = {
+            'foo': 'test',
+            'request': 'bar',
+            'bar': 'baz',
+        }
+        if DJANGO_1_5_OR_HIGHER:
+            expected.update({
+                'None': None,
+                'True': True,
+                'False': False,
+            })
+
+        # Adding a requestcontext to a plain context
+        context = Context({'foo': 'bar'})
+        context.push()
+        context.update({'bar': 'baz'})
+        context.push()
+        rcontext = RequestContext(request, {'request': 'bar'})
+        context.update(rcontext)
+        context.push()
+        context.update({'foo': 'test'})
+        flat = utils.flatten_context(context)
+        self.assertEqual(flat, expected)
+
+        # Adding a plain context to a requestcontext
+        context = RequestContext(request, {'request': 'bar'})
+        normal_context = Context({'foo': 'bar'})
+        context.push()
+        context.update({'bar': 'baz'})
+        context.push()
+        context.update(normal_context)
+        context.push()
+        context.update({'foo': 'test'})
+        flat = utils.flatten_context(context)
+        self.assertEqual(flat, expected)
+
+        # Adding a requestcontext to a requestcontext
+        context = RequestContext(request, {'request': 'bar'})
+        rcontext = RequestContext(request, {'foo': 'bar'})
+        context.push()
+        context.update({'bar': 'baz'})
+        context.push()
+        context.update(rcontext)
+        context.push()
+        context.update({'foo': 'test'})
+        flat = utils.flatten_context(context)
+        self.assertEqual(flat, expected)

--- a/classytags/utils.py
+++ b/classytags/utils.py
@@ -1,9 +1,15 @@
 import re
 from copy import copy
+from distutils.version import LooseVersion
 
 from classytags.compat import compat_basestring
+from django import get_version
 from django.template import Context, RequestContext
 from django.template.context import BaseContext
+
+DJANGO_1_9_OR_HIGHER = (
+    LooseVersion(get_version()) >= LooseVersion('1.9')
+)
 
 
 class NULL:
@@ -97,11 +103,8 @@ def flatten_compat(context):
 
 
 def flatten_context(context):
-    if callable(getattr(context, 'flatten', None)):
-        try:
-            return context.flatten()
-        except ValueError:
-            return flatten_compat(context)
+    if callable(getattr(context, 'flatten', None)) and DJANGO_1_9_OR_HIGHER:
+        return context.flatten()
     elif isinstance(context, BaseContext):
         return flatten_compat(context)
     return context

--- a/classytags/utils.py
+++ b/classytags/utils.py
@@ -2,7 +2,7 @@ import re
 from copy import copy
 
 from classytags.compat import compat_basestring
-from django.template import RequestContext
+from django.template import Context, RequestContext
 from django.template.context import BaseContext
 
 
@@ -89,7 +89,7 @@ def mixin(parent, child, attrs=None):
 def flatten_compat(context):
     flat = {}
     for d in context.dicts:
-        if isinstance(d, RequestContext):
+        if isinstance(d, (Context, RequestContext)):
             flat.update(flatten_compat(d))
         else:
             flat.update(d)


### PR DESCRIPTION
Issue seems to be related to Django issue #26041 (https://code.djangoproject.com/ticket/26041)

I had this issue with latest ``Django CMS`` release (3.2.0) but I think all cms versions are affected.

This PR introduces a workaround to avoid calling dict.update method if ``RequestContext`` is present in context.dicts, since it has lack of dict-like behavior.