### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ django-classy-tags
 ==================
 
 Please refer to the documentation in the docs/ directory for help. For a HTML
-rendered version of it please see `here <http://django-classy-tags.rtfd.org>`_.
+rendered version of it please see `here <https://django-classy-tags.readthedocs.io>`_.
 
 .. image:: https://travis-ci.org/ojii/django-classy-tags.svg?branch=master
     :target: https://travis-ci.org/ojii/django-classy-tags


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.