### PR TITLE
[Django 1.10] Defines TEMPLATES[] object

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -32,6 +32,19 @@ else:
 
 ROOT_URLCONF = 'runtests'
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [
+            os.path.join(os.path.dirname(__file__), 'test_templates'),
+        ],
+        'OPTIONS': {
+            'debug': True,
+        },
+    },
+]
+
 def main():
     import django
     from django.conf import settings
@@ -43,6 +56,7 @@ def main():
         TEMPLATE_DIRS = TEMPLATE_DIRS,
         TEMPLATE_DEBUG = TEMPLATE_DEBUG,
         MIDDLEWARE_CLASSES = [],
+        TEMPLATES=TEMPLATES,
     )
 
     # Run the test suite, including the extra validation tests.


### PR DESCRIPTION
In Django 1.8 was introduce the new TEMPLATES[] object, which replaces the old TEMPLATE_* in Django settings. With Django 1.10, not setting it up breaks everything.

This patch defines TEMPLATES in runtests.py to avoid failure in 1.10.
